### PR TITLE
Updated publicHeadersPath for ICUStubData

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -88,7 +88,7 @@ let package = Package(
             name: "ICUStubData",
             dependencies: ["ICUCommon"],
             path: "icuSources/stubdata",
-            publicHeadersPath: "include",
+            publicHeadersPath: ".",
             cxxSettings: stubDataBuildSettings),
     ],
     cxxLanguageStandard: .cxx11


### PR DESCRIPTION
Git ignores the empty `include` folder, causing downstream build to fail. This patch updates `ICUStubData`'s `publicHeaderPath` to `.` to avoid this issue.