### PR TITLE
build: indicate that we are building ICU statically

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let buildSettings: [CXXSetting] = [
     .define("DEBUG", to: "1", .when(configuration: .debug)),
     .define("U_SHOW_CPLUSPLUS_API", to: "1"),
     .define("U_SHOW_INTERNAL_API", to: "1"),
+    .define("U_STATIC_IMPLEMENTATION"),
     .define("U_TIMEZONE", to: "timezone"),
     .define("U_TIMEZONE_PACKAGE", to: "\"icutz44l\""),
     .define("FORTIFY_SOURCE", to: "2"),


### PR DESCRIPTION
We need to explicitly specify that we are building ICU statically as this changes the build model for Windows.  Since the products are static and the targets are built statically, simply assume static builds rather than dynamic builds.  This allows us to partially build this on Windows.