### PR TITLE
Disable embedded package data for Android

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,18 @@
 
 import PackageDescription
 
+let allPlatforms: [Platform] = [
+    .iOS,
+    .macOS,
+    .tvOS,
+    .watchOS,
+    .macCatalyst,
+    .driverKit,
+    .android,
+    .linux,
+    .windows,
+  ]
+
 var buildSettings: [CXXSetting] = [
   .define("DEBUG", to: "1", .when(configuration: .debug)),
   .define("U_ATTRIBUTE_DEPRECATED", to: ""),
@@ -10,18 +22,7 @@ var buildSettings: [CXXSetting] = [
   .define("U_SHOW_INTERNAL_API", to: "1"),
   .define("U_STATIC_IMPLEMENTATION"),
   .define("U_TIMEZONE", to: "_timezone", .when(platforms: [.windows])),
-  .define(
-    "U_TIMEZONE", to: "timezone",
-    .when(platforms: [
-      .iOS,
-      .macOS,
-      .tvOS,
-      .watchOS,
-      .macCatalyst,
-      .driverKit,
-      .android,
-      .linux,
-    ])),
+  .define("U_TIMEZONE", to: "timezone", .when(platforms: allPlatforms.filter({ $0 != .windows }))),
   .define("U_TIMEZONE_PACKAGE", to: "\"icutz44l\""),
   .define("U_HAVE_TZSET", to: "0", .when(platforms: [.wasi])),
   .define("U_HAVE_TZNAME", to: "0", .when(platforms: [.wasi])),
@@ -45,7 +46,8 @@ var buildSettings: [CXXSetting] = [
 
   // Where data are stored
   .define("ICU_DATA_DIR", to: "\"/usr/share/icu/\""),
-  .define("USE_PACKAGE_DATA", to: "1"),
+  .define("ICU_DATA_DIR_PREFIX_ENV_VAR", to: "\"ICU_DATA_DIR_PREFIX\""),
+  .define("USE_PACKAGE_DATA", to: "1", .when(platforms: allPlatforms.filter({ $0 != .android }))),
   .define("APPLE_ICU_CHANGES", to: "1"),
 
   .headerSearchPath("common"),

--- a/icuSources/common/udata.cpp
+++ b/icuSources/common/udata.cpp
@@ -711,7 +711,6 @@ openCommonData(const char *path,          /*  Path from OpenChoice?          */
                 }
             }
 #endif
-#endif
         }
 
         /* Add the linked-in data to the list. */

--- a/icuSources/common/udata.cpp
+++ b/icuSources/common/udata.cpp
@@ -701,9 +701,8 @@ openCommonData(const char *path,          /*  Path from OpenChoice?          */
             if(gCommonICUDataArray[commonDataIndex] != nullptr) {
                 return gCommonICUDataArray[commonDataIndex];
             }
-#if !defined(ICU_DATA_DIR_WINDOWS)
+#if defined(USE_PACKAGE_DATA) && !defined(ICU_DATA_DIR_WINDOWS)
 // When using the Windows system data, we expect only a single data file.
-#if defined(USE_PACKAGE_DATA)
             int32_t i;
             for(i = 0; i < commonDataIndex; ++i) {
                 if(gCommonICUDataArray[i]->pHeader == &U_ICUDATA_ENTRY_POINT) {
@@ -728,15 +727,13 @@ openCommonData(const char *path,          /*  Path from OpenChoice?          */
             setCommonICUDataPointer(uprv_getICUData_conversion(), false, pErrorCode);
         }
         */
-#if !defined(ICU_DATA_DIR_WINDOWS)
+#if defined(USE_PACKAGE_DATA) && !defined(ICU_DATA_DIR_WINDOWS)
 // When using the Windows system data, we expect only a single data file.
-#if defined(USE_PACKAGE_DATA)
         setCommonICUDataPointer(&U_ICUDATA_ENTRY_POINT, false, pErrorCode);
         {
             Mutex lock;
             return gCommonICUDataArray[commonDataIndex];
         }
-#endif
 #endif
     }
 

--- a/icuSources/common/udata.cpp
+++ b/icuSources/common/udata.cpp
@@ -703,6 +703,7 @@ openCommonData(const char *path,          /*  Path from OpenChoice?          */
             }
 #if !defined(ICU_DATA_DIR_WINDOWS)
 // When using the Windows system data, we expect only a single data file.
+#if defined(USE_PACKAGE_DATA)
             int32_t i;
             for(i = 0; i < commonDataIndex; ++i) {
                 if(gCommonICUDataArray[i]->pHeader == &U_ICUDATA_ENTRY_POINT) {
@@ -710,6 +711,7 @@ openCommonData(const char *path,          /*  Path from OpenChoice?          */
                     return nullptr;
                 }
             }
+#endif
 #endif
         }
 
@@ -728,11 +730,13 @@ openCommonData(const char *path,          /*  Path from OpenChoice?          */
         */
 #if !defined(ICU_DATA_DIR_WINDOWS)
 // When using the Windows system data, we expect only a single data file.
+#if defined(USE_PACKAGE_DATA)
         setCommonICUDataPointer(&U_ICUDATA_ENTRY_POINT, false, pErrorCode);
         {
             Mutex lock;
             return gCommonICUDataArray[commonDataIndex];
         }
+#endif
 #endif
     }
 


### PR DESCRIPTION
Embedded ICU data is problematic for Android apps:

1. It is duplicated for each architecture (`aarch64-linux-android/lib_FoundationICU.so` 40M, `arm-linux-androideabi/lib_FoundationICU.so` 37M, `x86_64-linux-android/lib_FoundationICU.so` 39M)
2. Native libraries on Android are stored uncompressed in the .apk

These problems result in extremely large Android apps when they depend on `FoundationInternationalization`. E.g., see https://github.com/skiptools/skipapp-hiya/releases/tag/0.1.0

As discussed at https://forums.swift.org/t/android-app-size-and-lib-foundationicu-so/78399, one possible solution would be to externalize the data and load the data from the file, which could then be shipped compressed as a single asset in the Android app. The app startup process would be responsible for extracting the data from the assets and writing it to a cached location, and then setting the `ICU_DATA_DIR_PREFIX` to the data's root folder.

This draft PR enables using an external data file on Android by default, and some testing against the macOS-provided `/usr/share/icu/icudt74l.dat` file shows that it works the same as if the data is embedded.