### PR TITLE
[FreeBSD] Cmake build should not set U_TIMEZONE for FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "WASI")
         $<$<COMPILE_LANGUAGE:C,CXX>:_WASI_EMULATED_MMAN>)
     add_link_options("-Lwasi-emulated-signal")
     add_link_options("-Lwasi-emulated-mman")
+elseif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 else()
     add_compile_definitions(
         $<$<COMPILE_LANGUAGE:C,CXX>:U_TIMEZONE=timezone>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "WASI")
     add_link_options("-Lwasi-emulated-signal")
     add_link_options("-Lwasi-emulated-mman")
 elseif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+    # On FreeBSD, we should not set U_TIMEZONE
 else()
     add_compile_definitions(
         $<$<COMPILE_LANGUAGE:C,CXX>:U_TIMEZONE=timezone>)


### PR DESCRIPTION
Currently cmake unconditionally set `U_TIMEZONE=timezone` for anything non-windows. This breaks building on FreeBSD using cmake. On FreeBSD, we should not set `U_TIMEZONE` at all. https://github.com/swiftlang/swift-foundation-icu/blob/5b6bcf1e163b9f6185b706da2890447b3fcac9fc/icuSources/common/putilimp.h#L127-L129