### PR TITLE
Add main --> release/6.2 automerger

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,17 @@
+name: Create PR to merge main into release branch
+# In the first period after branching the release branch, we typically want to include many changes from `main` in the release branch. This workflow automatically creates a PR every Monday to merge main into the release branch.
+# Later in the release cycle we should stop this practice to avoid landing risky changes by disabling this workflow. To do so, disable the workflow as described in https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/disabling-and-enabling-a-workflow
+on:
+  schedule:
+    - cron: '0 9 * * MON'
+  workflow_dispatch:
+jobs:
+  create_merge_pr:
+    name: Create PR to merge main into release branch
+    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
+    with:
+      base_branch: release/6.2
+    permissions:
+      contents: write
+      pull-requests: write
+    if: (github.event_name == 'schedule' && github.repository == 'swiftlang/swift-foundation-icu') || (github.event_name != 'schedule')  # Ensure that we don't run this on a schedule in a fork


### PR DESCRIPTION
Some other swiftlang repos have adopted this already - this adds a workflow which automatically creates a main --> release/6.2 PR every Monday at 9am which we will use to merge changes back to release/6.2 until later in the release cycle.