### PR TITLE
[6.2.1][CMake] Use new 16 KB page alignment on 64-bit Android (#71)

### DIFF
--- a/icuSources/CMakeLists.txt
+++ b/icuSources/CMakeLists.txt
@@ -35,6 +35,10 @@ if(LINKER_SUPPORTS_BUILD_ID)
   target_link_options(_FoundationICU PRIVATE "LINKER:--build-id=sha1")
 endif()
 
+if(ANDROID)
+  target_link_options(_FoundationICU PRIVATE "LINKER:-z,max-page-size=16384")
+endif()
+
 # Copy Headers to known directory for direct client (XCTest) test builds
 file(COPY
         include/


### PR DESCRIPTION
__Explanation:__ Add a linker flag for the upcoming 16 KB page support in Android.

__Scope:__ Only affects Android

__Issue:__ None

__Original PR:__ #71

__Risk:__ None, only affects Android

__Testing:__ Passed trunk and release/6.2 CI and confirmed locally that this fixed the alignment

__Reviewer:__ @compnerd

@swift-ci test