### PR TITLE
CMake: modulemap file override as build interface

### DIFF
--- a/icuSources/CMakeLists.txt
+++ b/icuSources/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(_FoundationICU
         include/)
 
 target_compile_options(_FoundationICU INTERFACE
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/include/_foundation_unicode/module.modulemap>")
+  "$<BUILD_INTERFACE:$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/include/_foundation_unicode/module.modulemap>>")
 
 add_subdirectory(common)
 add_subdirectory(i18n)


### PR DESCRIPTION
We should only be pulling in the modulemap file from the source directory when compiling against the build directory, not the installed location. The module-map-file override should only be applied as part of the build interface, not install interface. In cases where the sources are checked out and we are compiling a project against the install interface, we will run into a situation where the compiler sees the modulemap from both the installed location and the source directory and will complain.