### PR TITLE
chore: restrict GitHub workflow permissions - future-proof

### DIFF
--- a/.github/workflows/automerge_to_main.yml
+++ b/.github/workflows/automerge_to_main.yml
@@ -1,6 +1,8 @@
 name: Create PR to merge release branch into the main branch
 # At the end of a release cycle, we may want to automatically include all changes to release branches on the main branch to avoid the need for cherry-picking changes back to release branches
 # This workflow can be disabled earlier in the release cycle in the GitHub UI as described in https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/disabling-and-enabling-a-workflow
+permissions:
+  contents: read
 on:
   schedule:
     - cron: '0 9 * * *'

--- a/.github/workflows/automerge_to_release.yml
+++ b/.github/workflows/automerge_to_release.yml
@@ -1,6 +1,8 @@
 name: Create PR to merge main into release branch
 # In the first period after branching the release branch, we typically want to include many changes from `main` in the release branch. This workflow automatically creates a PR every Monday to merge main into the release branch.
 # Later in the release cycle we should stop this practice to avoid landing risky changes by disabling this workflow. To do so, disable the workflow as described in https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/disabling-and-enabling-a-workflow
+permissions:
+  contents: read
 on:
   schedule:
     - cron: '0 9 * * MON'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,5 +1,8 @@
 name: Pull request
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
See https://github.com/swiftlang/github-workflows/issues/167 for additional context

This approach aligns with security best practices, as detailed in the following documentation:

- https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes
- https://openssf.org/blog/2024/08/12/mitigating-attack-vectors-in-github-workflows/
