### PR TITLE
Disable format check in github actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,6 +21,7 @@ jobs:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
     with:
+      format_check_enabled: false
       license_header_check_project_name: "Swift.org"
       license_header_check_enabled: false
       unacceptable_language_check_enabled: false


### PR DESCRIPTION
Currently the format check isn't enabled in [swift-foundation](https://github.com/itingliu/swift-foundation/blame/32fd38c918b8c9b19288435faf27b53302c22ce0/.github/workflows/pull_request.yml#L47).

Disable the format check in swift-foundation-icu to be consistent with swift-foundation.
