### PR TITLE
Add messageformat2_arguments.h to module map

### DIFF
--- a/icuSources/include/_foundation_unicode/module.modulemap
+++ b/icuSources/include/_foundation_unicode/module.modulemap
@@ -128,6 +128,7 @@ module _FoundationICU {
     header "symtable.h"
     header "ucasemap.h"
     header "ucoleitr.h"
+    header "messageformat2_arguments.h"
     header "messageformat2_function_registry.h"
     header "compactdecimalformat.h"
     header "unum.h"


### PR DESCRIPTION
https://github.com/swiftlang/swift-foundation-icu/pull/80 added some new files, but module.modulemap is missing `messageformat2_arguments.h` so adding it. this is causing build breaks using the resulting module map. see [example](https://github.com/thebrowsercompany/swift-build/actions/runs/18666791524/job/53230132439)